### PR TITLE
add testing of odd auth and password reset flows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,8 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Start a pocketbase database instance for api testing
         run: |
-          wget -qO- https://github.com/pocketbase/pocketbase/releases/download/v0.12.2/pocketbase_0.12.2_linux_amd64.zip | sudo bsdtar -xvf- --include pocketbase -C /usr/bin
-          sudo chmod 755 /usr/bin/pocketbase
-          pocketbase serve --dir `mktemp -d` & 
+          export TMP_EMAIL_DIR=`mktemp -d`
+          bash ./tests/utils/pocketbase &
           sleep 1 
       - name: Lint with flake8
         run: |

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ pocketbase/models/utils/base_model.py               22      0   100%
 pocketbase/models/utils/list_result.py              10      0   100%
 pocketbase/models/utils/schema_field.py             11      0   100%
 pocketbase/services/__init__.py                      7      0   100%
-pocketbase/services/admin_service.py                42      6    86%
-pocketbase/services/collection_service.py           12      2    83%
+pocketbase/services/admin_service.py                40      0   100%
+pocketbase/services/collection_service.py           11      0   100%
 pocketbase/services/log_service.py                  27      0   100%
-pocketbase/services/realtime_service.py             88      8    91%
-pocketbase/services/record_service.py              104     22    79%
-pocketbase/services/settings_service.py             13      2    85%
+pocketbase/services/realtime_service.py             88      3    97%
+pocketbase/services/record_service.py              103      8    92%
+pocketbase/services/settings_service.py             11      0   100%
 pocketbase/services/utils/__init__.py                4      0   100%
 pocketbase/services/utils/base_crud_service.py      37      0   100%
 pocketbase/services/utils/base_service.py            7      0   100%
@@ -85,7 +85,7 @@ pocketbase/stores/base_auth_store.py                23      0   100%
 pocketbase/stores/local_auth_store.py               46      0   100%
 pocketbase/utils.py                                 26      0   100%
 --------------------------------------------------------------------
-TOTAL                                              784     46    94%
+TOTAL                                              778     17    98%
 ```
 
 <p align="center"><i>The PocketBase Python SDK is <a href="https://github.com/m29h/pocketbase/blob/master/LICENCE.txt">MIT licensed</a> code.</p>

--- a/pocketbase/services/admin_service.py
+++ b/pocketbase/services/admin_service.py
@@ -12,8 +12,6 @@ class AdminAuthResponse:
     def __init__(self, token: str, admin: Admin, **kwargs) -> None:
         self.token = token
         self.admin = admin
-        for key, value in kwargs.items():
-            setattr(self, key, value)
 
 
 class AdminService(CrudService):
@@ -115,7 +113,7 @@ class AdminService(CrudService):
                 "passwordConfirm": password_confirm,
             }
         )
-        return self.auth_response(
+        return (
             self.client.send(
                 self.base_crud_path() + "/confirm-password-reset",
                 {
@@ -124,4 +122,5 @@ class AdminService(CrudService):
                     "body": body_params,
                 },
             )
+            is None
         )

--- a/pocketbase/services/collection_service.py
+++ b/pocketbase/services/collection_service.py
@@ -25,12 +25,17 @@ class CollectionService(CrudService):
         that are not present in the imported configuration, WILL BE DELETED
         (including their related records data)!
         """
-        self.client.send(
-            self.base_crud_path() + "/import",
-            {
-                "method": "PUT",
-                "params": query_params,
-                "body": {"collections": collections, "deleteMissing": delete_missing},
-            },
+        return (
+            self.client.send(
+                self.base_crud_path() + "/import",
+                {
+                    "method": "PUT",
+                    "params": query_params,
+                    "body": {
+                        "collections": collections,
+                        "deleteMissing": delete_missing,
+                    },
+                },
+            )
+            is None
         )
-        return True

--- a/pocketbase/services/realtime_service.py
+++ b/pocketbase/services/realtime_service.py
@@ -55,7 +55,7 @@ class RealtimeService(BaseService):
                 to_unsubscribe.append(sub)
         if len(to_unsubscribe) == 0:
             return
-        return self.unsubscribe(*to_unsubscribe)
+        return self.unsubscribe(to_unsubscribe)
 
     def unsubscribe(self, subscriptions: List[str] | None = None) -> None:
         """
@@ -74,11 +74,13 @@ class RealtimeService(BaseService):
         else:
             # remove each passed subscription
             found = False
-            sub_keys = list(self.subscriptions.keys())
-            for sub in sub_keys:
-                found = True
-                self.event_source.remove_event_listener(sub, self.subscriptions[sub])
-                self.subscriptions.pop(sub)
+            for sub in subscriptions:
+                if sub in self.subscriptions:
+                    found = True
+                    self.event_source.remove_event_listener(
+                        sub, self.subscriptions[sub]
+                    )
+                    self.subscriptions.pop(sub)
             if not found:
                 return
 

--- a/pocketbase/services/settings_service.py
+++ b/pocketbase/services/settings_service.py
@@ -24,11 +24,13 @@ class SettingsService(BaseService):
 
     def test_s3(self, query_params: dict = {}) -> bool:
         """Performs a S3 storage connection test."""
-        self.client.send(
-            "/api/settings/test/s3",
-            {"method": "POST", "params": query_params},
+        return (
+            self.client.send(
+                "/api/settings/test/s3",
+                {"method": "POST", "params": query_params},
+            )
+            is None
         )
-        return True
 
     def test_email(
         self, to_email: str, email_template: str, query_params: dict = {}
@@ -41,12 +43,15 @@ class SettingsService(BaseService):
         - password-reset
         - email-change
         """
-        self.client.send(
-            "/api/settings/test/email",
-            {
-                "method": "POST",
-                "params": query_params,
-                "body": {"email": to_email, "template": email_template},
-            },
+
+        return (
+            self.client.send(
+                "/api/settings/test/email",
+                {
+                    "method": "POST",
+                    "params": query_params,
+                    "body": {"email": to_email, "template": email_template},
+                },
+            )
+            is None
         )
-        return True

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -70,3 +70,27 @@ def test_get_nonexisting_exception(client):
     with pytest.raises(ClientResponseError) as exc:
         client.collections.get_one(uuid4().hex)
     assert exc.value.status == 404
+
+
+def test_import_collection(client):
+    data = [
+        {
+            "name": uuid4().hex,
+            "schema": [
+                {
+                    "name": "status",
+                    "type": "bool",
+                },
+            ],
+        },
+        {
+            "name": uuid4().hex,
+            "schema": [
+                {
+                    "name": "title",
+                    "type": "text",
+                },
+            ],
+        },
+    ]
+    assert client.collections.import_collections(data)

--- a/tests/test_record_event.py
+++ b/tests/test_record_event.py
@@ -45,6 +45,8 @@ class TestRecordEventService:
             assert e.record.collection_id == state.coll.id
             assert e.record.id == state.record.id
         c.unsubscribe()
+        c.unsubscribe()
+        client.realtime.unsubscribe([])
         sleep(0.1)
         for _ in range(2):
             state.c.create({"title": uuid4().hex})
@@ -59,9 +61,14 @@ class TestRecordEventService:
         r: Record = state.record
         state.test_subscribe_event2 = None
 
+        def callback_ex(e: MessageData):
+            raise Exception("This Callback should be never called")
+
         def callback(e: MessageData):
             state.test_subscribe_event2 = e
 
+        c.subscribeOne(r.id, callback_ex)
+        # subscribing a second time should erase first subscription (for code coverage)
         c.subscribeOne(r.id, callback)
         sleep(0.1)
         for _ in range(2):
@@ -71,7 +78,7 @@ class TestRecordEventService:
             assert e.record.collection_id == state.coll.id
             assert e.record.id == r.id
             state.test_subscribe_event2.record.id = "abc"
-        c.unsubscribe()
+        c.unsubscribe(r.id, r.id)
         sleep(0.1)
 
         for _ in range(2):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,6 +5,7 @@ __all__ = ("client", "state")
 import pytest
 from pocketbase.utils import ClientResponseError
 from uuid import uuid4
+from os import environ, path
 
 
 class TestSettingsService:
@@ -23,9 +24,9 @@ class TestSettingsService:
         assert state.appname == settings["meta"]["appName"]
 
     def test_email(self, client: PocketBase, state):
-        with pytest.raises(ClientResponseError) as exc:
-            client.settings.test_email("", "")
-        assert exc.value.status == 400
+        addr = uuid4().hex
+        assert client.settings.test_email(f"settings@{addr}.com", "verification")
+        assert path.exists(environ.get("TMP_EMAIL_DIR") + f"/settings@{addr}.com")
 
     def test_s3(self, client: PocketBase, state):
         with pytest.raises(ClientResponseError) as exc:

--- a/tests/utils/pocketbase
+++ b/tests/utils/pocketbase
@@ -1,6 +1,11 @@
 #!/bin/bash
 #get latest release version number
-cd `mktemp -d`
+DBDIR=`mktemp -d`
+#export TMP_EMAIL_DIR=`mktemp -d`
+cp tests/utils/sendmail ${DBDIR}
+chmod 755 ${DBDIR}/sendmail
+cd ${DBDIR}
+export PATH=${DBDIR}:$PATH
 release=$(curl -IkLs -o /dev/null -w %{url_effective} https://github.com/pocketbase/pocketbase/releases/latest|grep -o "[^/]*$"| sed "s/v//g")
 echo ${release}
 wget -qO- https://github.com/pocketbase/pocketbase/releases/download/v${release}/pocketbase_${release}_linux_amd64.zip | bsdtar -xvf- --include pocketbase -C .

--- a/tests/utils/sendmail
+++ b/tests/utils/sendmail
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [[ -n "${TMP_EMAIL_DIR}" ]]; then
+cat - > ${TMP_EMAIL_DIR}/${1}
+fi


### PR DESCRIPTION
Bugfix Realtime service logic
implement a mock for the sendmail call of the pocketbase database
fix handle Null return value in various password reset and email change workflows as obtained by testing 
Code Coverage now 98% :+1: 